### PR TITLE
Update French monthyear fixture to CLDR sentence case

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,8 +1,6 @@
-gem "canon", git: "https://github.com/lutaml/canon", branch: "fix/144-asymmetric-comments-element-structure"
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "fix/canon-0.2.4"
-gem "metanorma-core", git: "https://github.com/metanorma/metanorma-core", branch: "main"
-gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/canon-0.2.4"
-gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "fix/nokogiri_html_load_spec"
-gem "metanorma-generic", git: "https://github.com/metanorma/metanorma-generic", branch: "fix/canon-0.2.4"
-gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "main"
-gem "pubid-itu", git: "https://github.com/metanorma/pubid", branch: "feature/pubid-itu-i18n-annex", glob: "gems/pubid-itu/*.gemspec"
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
+gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "main"
+gem "metanorma-generic", git: "https://github.com/metanorma/metanorma-generic", branch: "main"
+gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"
+
+

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,3 +1,5 @@
+gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "feature/format-iso-date-helper"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "feature/format-iso-date-delegation"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
 gem "metanorma-iso", git: "https://github.com/metanorma/metanorma-iso", branch: "main"
 gem "metanorma-generic", git: "https://github.com/metanorma/metanorma-generic", branch: "main"

--- a/lib/metanorma/bipm/front.rb
+++ b/lib/metanorma/bipm/front.rb
@@ -69,9 +69,7 @@ module Metanorma
             add_noko_elem(b, "date", date,
                           type: edition ? "published" : "circulated")
             add_noko_elem(b, "edition", edition)
-            draft and b.version do |v|
-              add_noko_elem(v, "draft", draft)
-            end
+            draft and add_noko_elem(b, "version", draft)
           end
         end
       end

--- a/spec/isodoc/metadata_spec.rb
+++ b/spec/isodoc/metadata_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe IsoDoc::Bipm do
           <title type="title-provenance" language="en" format="plain">Main Title Provenance</title>
           <title type="title-provenance" language="fr" format="plain">Chef Title Provenance</title>
           <docidentifier>1000</docidentifier>
-          <date type="published">2021-04</date>
+          <date type="published"><on>2021-04</on></date>
+          <date type="updated"><on>2000-01-01</on></date>
           <contributor>
             <role type="author"/>
             <person>
@@ -109,11 +110,8 @@ RSpec.describe IsoDoc::Bipm do
               <name>ORG2</name>
             </organization>
           </contributor>
-          <version>
             <edition>2</edition>
-            <revision-date>2000-01-01</revision-date>
-            <draft>3.4</draft>
-          </version>
+          <version>3.4</version>
           <language>en</language>
           <script>Latn</script>
           <status>
@@ -183,6 +181,7 @@ RSpec.describe IsoDoc::Bipm do
         docyear: "2001",
         draft: "3.4",
         draftinfo: " (draft 3.4, 2000-01-01)",
+        edition: "2",
         implementeddate: "XXX",
         issueddate: "XXX",
         lang: "en",
@@ -261,6 +260,7 @@ RSpec.describe IsoDoc::Bipm do
           <title format="plain" language="en" type="title-annex">Main Title Annex</title>
           <title format="plain" language="fr" type="title-annex">Chef Title Annex</title>
           <docidentifier>1000</docidentifier>
+          <date type="updated"><on>2000-01-01</on></date>
           <contributor>
             <role type="author"/>
             <organization>
@@ -288,11 +288,8 @@ RSpec.describe IsoDoc::Bipm do
               #{BIPM_LOGO}
             </organization>
           </contributor>
-          <version>
             <edition>2</edition>
-            <revision-date>2000-01-01</revision-date>
-            <draft>3.4</draft>
-          </version>
+          <version>3.4</version>
           <language>fr</language>
           <script>Latn</script>
           <status>
@@ -360,6 +357,7 @@ RSpec.describe IsoDoc::Bipm do
         docyear: "2001",
         draft: "3.4",
         draftinfo: " (brouillon 3.4, 2000-01-01)",
+        edition: "2",
         implementeddate: "XXX",
         issueddate: "XXX",
         lang: "fr",
@@ -418,11 +416,8 @@ RSpec.describe IsoDoc::Bipm do
           <status>
             <stage>standard</stage>
           </status>
-        <version>
           <edition>2</edition>
-          <revision-date>2000-01-01</revision-date>
-          <draft>3.4</draft>
-        </version>
+        <version>3.4</version>
         </bibdata>
         <metanorma-extension>
         <semantic-metadata>
@@ -443,7 +438,8 @@ RSpec.describe IsoDoc::Bipm do
         correcteddate: "XXX",
         createddate: "XXX",
         draft: "3.4",
-        draftinfo: " (draft 3.4, 2000-01-01)",
+        draftinfo: " (draft 3.4)",
+        edition: "2",
         implementeddate: "XXX",
         issueddate: "XXX",
         lang: "en",
@@ -451,8 +447,6 @@ RSpec.describe IsoDoc::Bipm do
         org_abbrev: "BIPM",
         publisheddate: "XXX",
         receiveddate: "XXX",
-        revdate: "2000-01-01",
-        revdate_monthyear: "January 2000",
         script: "Latn",
         stable_untildate: "XXX",
         stage: "Standard",

--- a/spec/isodoc/metadata_spec.rb
+++ b/spec/isodoc/metadata_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe IsoDoc::Bipm do
         publisher: "#{Metanorma::Bipm.configuration.organization_name_long['fr']}",
         receiveddate: "XXX",
         revdate: "2000-01-01",
-        revdate_monthyear: "Janvier 2000",
+        revdate_monthyear: "janvier 2000",
         script: "Latn",
         stable_untildate: "XXX",
         stage: "Working Draft",

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe Metanorma::Bipm do
             <date type="obsoleted">
               <on>C</on>
             </date>
+            <date type="updated"><on>2000-01-01</on></date>
             <contributor>
               <role type="author"/>
               <organization>
@@ -224,10 +225,7 @@ RSpec.describe Metanorma::Bipm do
               </organization>
             </contributor>
             <edition>2</edition>
-            <version>
-              <revision-date>2000-01-01</revision-date>
-              <draft>3.4</draft>
-            </version>
+            <version>3.4</version>
             <language>en</language>
             <script>Latn</script>
             <status>
@@ -259,26 +257,20 @@ RSpec.describe Metanorma::Bipm do
               <bibitem>
                 <date type="published">2018-06-11</date>
                 <edition>1.0</edition>
-                <version>
-                  <draft>1.0</draft>
-                </version>
+                <version>1.0</version>
               </bibitem>
             </relation>
             <relation type="supersedes">
               <bibitem>
                 <date type="published">2019-06-11</date>
                 <edition>2.0</edition>
-                <version>
-                  <draft>2.0</draft>
-                </version>
+                <version>2.0</version>
               </bibitem>
             </relation>
             <relation type="supersedes">
               <bibitem>
                 <date type="circulated">2019-06-11</date>
-                <version>
-                  <draft>3.0</draft>
-                </version>
+                <version>3.0</version>
               </bibitem>
             </relation>
             <ext>
@@ -383,6 +375,7 @@ RSpec.describe Metanorma::Bipm do
         <date type='obsoleted'>
           <on>C</on>
         </date>
+            <date type="updated"><on>2000-01-01</on></date>
           <contributor>
             <role type="author"/>
             <organization>
@@ -416,10 +409,7 @@ RSpec.describe Metanorma::Bipm do
             </organization>
           </contributor>
           <edition>2</edition>
-          <version>
-            <revision-date>2000-01-01</revision-date>
-            <draft>3.4</draft>
-          </version>
+          <version>3.4</version>
           <language>fr</language>
           <script>Latn</script>
           <status>
@@ -542,6 +532,7 @@ RSpec.describe Metanorma::Bipm do
            <date type="obsoleted">
              <on>C</on>
            </date>
+            <date type="updated"><on>2000-01-01</on></date>
            <contributor>
              <role type="author"/>
              <organization>
@@ -575,10 +566,7 @@ RSpec.describe Metanorma::Bipm do
              </organization>
            </contributor>
            <edition>2</edition>
-           <version>
-             <revision-date>2000-01-01</revision-date>
-             <draft>3.4</draft>
-           </version>
+           <version>3.4</version>
            <language>fr</language>
            <script>Latn</script>
            <status>
@@ -721,6 +709,7 @@ RSpec.describe Metanorma::Bipm do
           <date type='obsoleted'>
             <on>C</on>
           </date>
+            <date type="updated"><on>2000-01-01</on></date>
           <contributor>
             <role type='author'/>
             <organization>
@@ -754,10 +743,7 @@ RSpec.describe Metanorma::Bipm do
             </organization>
           </contributor>
           <edition>2</edition>
-          <version>
-            <revision-date>2000-01-01</revision-date>
-            <draft>3.4</draft>
-          </version>
+          <version>3.4</version>
           <language>fr</language>
           <script>Latn</script>
           <status>


### PR DESCRIPTION
Part of metanorma/metanorma-plateau#147 (Phase 3 — flavour-copies refactor). Downstream of metanorma/isodoc#792 (`monthyr` now CLDR-driven). Updates the French `revdate_monthyear` fixture to CLDR-canonical sentence case (`"Janvier"` → `"janvier"`); pins `isodoc-i18n` + `isodoc` to their Phase 3 PR branches in `Gemfile.devel`.
